### PR TITLE
feat: add support for environment variables

### DIFF
--- a/Editor/NeovimEditorConfig.cs
+++ b/Editor/NeovimEditorConfig.cs
@@ -14,9 +14,11 @@ namespace Neovim.Editor
     private bool m_Dirty = false;
 
     private int m_ProcessTimeout = 150;
-    public int ProcessTimeout {
+    public int ProcessTimeout
+    {
       get => m_ProcessTimeout;
-      set {
+      set
+      {
         if (value == m_ProcessTimeout)
           return;
         m_ProcessTimeout = value;
@@ -46,6 +48,19 @@ namespace Neovim.Editor
         if (value == m_TermLaunchArgs)
           return;
         m_TermLaunchArgs = value;
+        m_Dirty = true;
+      }
+    }
+
+    private string m_TermLaunchEnv;
+    public string TermLaunchEnv
+    {
+      get => m_TermLaunchEnv;
+      set
+      {
+        if (value == m_TermLaunchEnv)
+          return;
+        m_TermLaunchEnv = value;
         m_Dirty = true;
       }
     }


### PR DESCRIPTION
### Problem

Hi, I had issue to open neovim under wayland while Unity is under x11 (it was opening neovim under x11 by default which led to unwanted behavior related to my style config).

### FIX

To fix it I have implemented Env arguments passable within the neovim GUI config (similar to the cmd,args themself), I'm not too familiar with csharp yet so I basically copy/paste what was already there and adding the minimum code possible to fit the need.

It allows to pass env to the terminal cmd, I personally use it to pass the env `GDK_BACKEND=wayland` which seems to work fine for me.

If you think this is unnecessary or too niche, feel free to ignore this PR, I will just using my local fork instead.

### System info

Arch - 6.18.5-arch1-1
Hyprland - 0.53.1
Neovim - 0.11.5
Unity - 6000.3.4f1 LTS
